### PR TITLE
Replace pg_tester with standalone_migrations

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+# [1.1.1 - 2021-08-12]
+## Changed
+- Replaced `pg_tester` with `standalone_migrations` due to lack of cummon support of `pg` between `pg_tester` and `activerecord`. It has changed the approach to testing and requires additional db setup prior.
+
 # [1.0.1 - 2021-04-27]
 ## Changed
 - Use github packages as gem source for our own gems

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in activerecord-upsert_version.gemspec
 gemspec
@@ -9,5 +9,4 @@ group :development do
   source "https://rubygems.pkg.github.com/hubbado" do
     gem 'hubbado-style'
   end
-  gem 'pg', '~> 0.21.0'
 end

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Or install it yourself as:
 
 `ActiveRecord::UpsertVersion.(**attributes, version: <version>)`
 
+## Testing
+
+Run `RACK_ENV=test rake db:create` to prepare test database.
+Run `RACK_ENV=test rake db:migrate` to run migrations.
+Run `rspec` to test all scenarios.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require 'standalone_migrations'
 
 RSpec::Core::RakeTask.new(:spec)
+StandaloneMigrations::Tasks.load_tasks
 
-task :default => :spec
+task default: :spec

--- a/db/config.yml
+++ b/db/config.yml
@@ -1,0 +1,12 @@
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  pool: 5
+
+development:
+  <<: *default
+  database: hubbado-upsert_version_development
+
+test:
+  <<: *default
+  database: hubbado-upsert_version_test

--- a/db/migrate/20210812104601_create_models.rb
+++ b/db/migrate/20210812104601_create_models.rb
@@ -1,0 +1,10 @@
+class CreateModels < ActiveRecord::Migration[6.0]
+  def change
+    create_table :models, force: true do |t|
+      t.string :subject
+      t.integer :version
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210812104602_create_dual_constraint_models.rb
+++ b/db/migrate/20210812104602_create_dual_constraint_models.rb
@@ -1,0 +1,14 @@
+class CreateDualConstraintModels < ActiveRecord::Migration[6.0]
+  def change
+    create_table :dual_constraint_models, force: true do |t|
+      t.string :chat_id, unique: true
+      t.string :user_id, unique: true
+      t.string :company_id
+      t.integer :version
+
+      t.timestamps
+
+      t.index %i[chat_id user_id], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,35 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2021_08_12_104602) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "dual_constraint_models", force: :cascade do |t|
+    t.string "chat_id"
+    t.string "user_id"
+    t.string "company_id"
+    t.integer "version"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["chat_id", "user_id"], name: "index_dual_constraint_models_on_chat_id_and_user_id", unique: true
+  end
+
+  create_table "models", force: :cascade do |t|
+    t.string "subject"
+    t.integer "version"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+end

--- a/hubbado-upsert_version.gemspec
+++ b/hubbado-upsert_version.gemspec
@@ -35,8 +35,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "codecov"
+  spec.add_development_dependency "database_cleaner-active_record"
   spec.add_development_dependency "ffaker"
-  spec.add_development_dependency "pg_tester"
+  spec.add_development_dependency "pg"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency 'standalone_migrations'
 end

--- a/lib/hubbado/upsert_version/version.rb
+++ b/lib/hubbado/upsert_version/version.rb
@@ -1,5 +1,5 @@
 module Hubbado
   class UpsertVersion
-    VERSION = "1.0.1"
+    VERSION = "1.1.1"
   end
 end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -1,4 +1,5 @@
 module Support
   class Model < ActiveRecord::Base; end
+
   class DualConstraintModel < ActiveRecord::Base; end
 end


### PR DESCRIPTION
Replaced `pg_tester` with `standalone_migrations` due to lack of cummon support of `pg` between `pg_tester` and `activerecord`. It has changed the approach to testing and requires additional db setup prior.