### PR TITLE
Fix case when encrypted_attributes provided

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+# [1.1.2 - 2021-08-13]
+- Fix case when encrypted_attributes are available in the model but none of them was included in the changed attributes
+
 # [1.1.1 - 2021-08-12]
 ## Changed
 - Replaced `pg_tester` with `standalone_migrations` due to lack of cummon support of `pg` between `pg_tester` and `activerecord`. It has changed the approach to testing and requires additional db setup prior.

--- a/lib/hubbado/upsert_version.rb
+++ b/lib/hubbado/upsert_version.rb
@@ -53,7 +53,7 @@ module Hubbado
           "encrypted_#{key}_salt" => encrypted_record.send("encrypted_#{key}_salt"),
           "encrypted_#{key}_iv" => encrypted_record.send("encrypted_#{key}_iv")
         }
-      end.reduce(:merge)
+      end.reduce(:merge) || {}
 
       attributes.except(*attributes_for_encryption.keys).merge(encrypted_attribtues)
     end

--- a/lib/hubbado/upsert_version/version.rb
+++ b/lib/hubbado/upsert_version/version.rb
@@ -1,5 +1,5 @@
 module Hubbado
   class UpsertVersion
-    VERSION = "1.1.1"
+    VERSION = "1.1.2"
   end
 end

--- a/spec/hubbado/upsert_version_spec.rb
+++ b/spec/hubbado/upsert_version_spec.rb
@@ -130,6 +130,21 @@ RSpec.describe Hubbado::UpsertVersion do
           expect { subject.(attributes); model.reload }
             .not_to change { model.iban }
         end
+
+        context 'and no encrypted attribute is updated' do
+          let(:attributes) do
+            {
+              id: id,
+              version: new_version
+            }
+          end
+
+          it 'does update the existing model' do
+            expect { subject.(attributes); model.reload }
+              .to change { model.version }.from(model_version).to(new_version)
+              .and change { model.updated_at }
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Fixed case when encrypted_attributes are available in the model but none of them was included in the changed attributes