### PR TITLE
Insert and Update objects replace Upserted

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+# [Unrelased]
+## Changed
+- Upserted result is replaceed with Updated and Inserted
+
 # [2.3.0 - 2024-07-19]
 ## Added
 - `version_column_name` is introduced

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 # [Unrelased]
 ## Changed
-- Upserted result is replaceed with Updated and Inserted
+- Upserted result is replaced with Updated and Inserted
 
 # [2.3.0 - 2024-07-19]
 ## Added

--- a/lib/hubbado/upsert_version/controls.rb
+++ b/lib/hubbado/upsert_version/controls.rb
@@ -1,5 +1,6 @@
 require_relative 'controls/id'
 require_relative 'controls/version'
 require_relative 'controls/attributes'
+require_relative 'controls/inserted'
 require_relative 'controls/unchanged'
-require_relative 'controls/upserted'
+require_relative 'controls/updated'

--- a/lib/hubbado/upsert_version/controls/inserted.rb
+++ b/lib/hubbado/upsert_version/controls/inserted.rb
@@ -1,11 +1,11 @@
 module Hubbado
   class UpsertVersion
     module Controls
-      module Upserted
+      module Inserted
         def self.example(attributes = nil)
           attributes ||= Attributes.example
 
-          Hubbado::UpsertVersion::Upserted.new(attributes)
+          Hubbado::UpsertVersion::Inserted.new(attributes)
         end
       end
     end

--- a/lib/hubbado/upsert_version/controls/updated.rb
+++ b/lib/hubbado/upsert_version/controls/updated.rb
@@ -1,0 +1,13 @@
+module Hubbado
+  class UpsertVersion
+    module Controls
+      module Updated
+        def self.example(attributes = nil)
+          attributes ||= Attributes.example
+
+          Hubbado::UpsertVersion::Updated.new(attributes)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/hubbado/upsert_version/substitute_spec.rb
+++ b/spec/lib/hubbado/upsert_version/substitute_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Hubbado::UpsertVersion::Substitute do
 
   it 'can set the result' do
     caller = caller_class.new
-    result = Hubbado::UpsertVersion::Controls::Upserted.example
+    result = Hubbado::UpsertVersion::Controls::Updated.example
 
     caller.upsert_version.set_result(result)
 

--- a/spec/lib/hubbado/upsert_version_spec.rb
+++ b/spec/lib/hubbado/upsert_version_spec.rb
@@ -46,10 +46,10 @@ RSpec.describe Hubbado::UpsertVersion do
         expect(model.updated_at).to be_within(2.seconds).of(Time.current)
       end
 
-      it "returns a result with the upserted values" do
+      it "returns a result with the inserted values" do
         result = subject.(attributes)
 
-        expect(result.upserted?).to eq(true)
+        expect(result).to be_inserted
         expect(result.attributes).to include(
           **attributes
         )
@@ -69,10 +69,10 @@ RSpec.describe Hubbado::UpsertVersion do
             .and change { model.updated_at }
         end
 
-        it "returns a result with the upserted values" do
+        it "returns a result with the updated values" do
           result = subject.(attributes)
 
-          expect(result.upserted?).to eq(true)
+          expect(result).to be_updated
           expect(result.attributes).to include(
             **attributes
           )
@@ -86,10 +86,10 @@ RSpec.describe Hubbado::UpsertVersion do
           expect { subject.(attributes); model.reload }.not_to change { model.subject }
         end
 
-        it "does not return upserted result" do
+        it "returns an unchanged result" do
           result = subject.(attributes)
 
-          expect(result.upserted?).to eq(false)
+          expect(result).to be_unchanged
         end
       end
 
@@ -100,10 +100,10 @@ RSpec.describe Hubbado::UpsertVersion do
           expect { subject.(attributes); model.reload }.not_to change { model.subject }
         end
 
-        it "does not return upserted result" do
+        it "returns an unchanged result" do
           result = subject.(attributes)
 
-          expect(result.upserted?).to eq(false)
+          expect(result).to be_unchanged
         end
       end
     end
@@ -224,10 +224,10 @@ RSpec.describe Hubbado::UpsertVersion do
         expect { subject.(attributes) }.to change { model_class.count }.by 1
       end
 
-      it "returns a result with the upserted values" do
+      it "returns a result with the inserted values" do
         result = subject.(attributes)
 
-        expect(result.upserted?).to eq(true)
+        expect(result).to be_inserted
         expect(result.attributes).to include(
           **attributes
         )
@@ -253,10 +253,10 @@ RSpec.describe Hubbado::UpsertVersion do
             .and change { model.version }.from(model_version).to(new_version)
         end
 
-        it "returns a result with the upserted values" do
+        it "returns a result with the updated values" do
           result = subject.(attributes)
 
-          expect(result.upserted?).to eq(true)
+          expect(result).to be_updated
           expect(result.attributes).to include(
             **attributes
           )
@@ -270,10 +270,10 @@ RSpec.describe Hubbado::UpsertVersion do
           expect { subject.(attributes); model.reload }.not_to change { model.company_id }
         end
 
-        it "does not return upserted result" do
+        it "returns an unchanged result" do
           result = subject.(attributes)
 
-          expect(result.upserted?).to eq(false)
+          expect(result).to be_unchanged
         end
       end
 
@@ -284,10 +284,10 @@ RSpec.describe Hubbado::UpsertVersion do
           expect { subject.(attributes); model.reload }.not_to change { model.company_id }
         end
 
-        it "does not return upserted result" do
+        it "returns an unchanged result" do
           result = subject.(attributes)
 
-          expect(result.upserted?).to eq(false)
+          expect(result).to be_unchanged
         end
       end
     end
@@ -318,10 +318,10 @@ RSpec.describe Hubbado::UpsertVersion do
         expect(model.updated_at).to be_within(2.seconds).of(Time.current)
       end
 
-      it "returns a result with the upserted values" do
+      it "returns a result with the inserted values" do
         result = subject.(attributes)
 
-        expect(result.upserted?).to eq(true)
+        expect(result).to be_inserted
         expect(result.attributes).to include(
           **attributes
         )
@@ -341,10 +341,10 @@ RSpec.describe Hubbado::UpsertVersion do
             .and change { model.updated_at }
         end
 
-        it "returns a result with the upserted values" do
+        it "returns a result with the updated values" do
           result = subject.(attributes)
 
-          expect(result.upserted?).to eq(true)
+          expect(result).to be_updated
           expect(result.attributes).to include(
             **attributes
           )
@@ -358,10 +358,10 @@ RSpec.describe Hubbado::UpsertVersion do
           expect { subject.(attributes); model.reload }.not_to change { model.subject }
         end
 
-        it "does not return upserted result" do
+        it "returns an unchanged result" do
           result = subject.(attributes)
 
-          expect(result.upserted?).to eq(false)
+          expect(result).to be_unchanged
         end
       end
 
@@ -372,10 +372,10 @@ RSpec.describe Hubbado::UpsertVersion do
           expect { subject.(attributes); model.reload }.not_to change { model.subject }
         end
 
-        it "does not return upserted result" do
+        it "returns an unchanged result" do
           result = subject.(attributes)
 
-          expect(result.upserted?).to eq(false)
+          expect(result).to be_unchanged
         end
       end
     end


### PR DESCRIPTION
This allows the client of the gem to determine if the UPSERT caused an INSERT or UPDATE